### PR TITLE
[elastic] Fix deploy failure #Attempt 16.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_install:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - os: windows
   include:
     - name: Unit Tests & Package | Linux
       os: linux
@@ -65,27 +63,5 @@ matrix:
         verbose: true
         local_dir: $GOPATH/src/golang.org/x/tools/build
         target_branch: darwin_deploy
-        on:
-          branch: master
-
-    - name: Unit Tests & Package | Windows
-      os: windows
-      script:
-        # TODO(henrywong) fix the test failures on windows and enable the test.
-        # - go test ./internal/lsp
-        - go build -o go-langserver-windows-amd64 $GOPATH/src/golang.org/x/tools/cmd/gopls
-        - curl -o ../go1.12.7.windows-amd64.zip https://dl.google.com/go/go1.12.7.windows-amd64.zip
-        - 7z x ../go1.12.7.windows-amd64.zip -ogo-toolchain
-        - rm go-toolchain/go/bin/godoc & rm go-toolchain/go/bin/gofmt & rm go-toolchain/go/misc/benchcmp & rm go-toolchain/go/misc/nacl/go_nacl* & rm -r go-toolchain/go/pkg/tool/windows_amd64
-        - mkdir build
-        - 7z a -r ./build/go-langserver-windows-amd64.zip go-langserver-windows-amd64 go-toolchain/go
-        - choco install rsync
-      deploy:
-        provider: pages
-        skip_cleanup: true
-        github_token: $GITHUB_TOKEN
-        verbose: true
-        local_dir: $GOPATH/src/golang.org/x/tools/build
-        target_branch: windows_deploy
         on:
           branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+image: Visual Studio 2017
+
+clone_folder: c:\gopath\src\golang.org\x\tools
+
+environment:
+  GOPATH: c:\gopath
+  GO111MODULE: off
+  GOPROXY: "https://proxy.golang.org"
+  github_access_token:
+    secure: h4ICNdm1D4g1klCMU6lQ7t92lwIrzo2HHzqc9MJpZdibgfNNFNGwywHWyBa0KPpL
+  github_email:
+    secure: h0I1jhHT32GpepMnqGjwM+Fjyhf+WYtr5D1J+IkSdgg=
+
+stack: go 1.12.x
+
+build_script:
+  - go get golang.org/x/sync/errgroup
+  # TODO(henrywong) For now, there are problems about the windows test.
+  # - go test ./internal/lsp -v
+  - go build -o go-langserver-windows-amd64 c:\gopath\src\golang.org\x\tools\cmd\gopls
+  - curl -o ../go1.12.7.windows-amd64.zip https://dl.google.com/go/go1.12.7.windows-amd64.zip
+  - 7z x ../go1.12.7.windows-amd64.zip -o..
+  - cd .. & mkdir build
+  - rm go/bin/godoc & rm go/bin/gofmt & rm go/misc/benchcmp & rm go/misc/nacl/go_nacl* & rm -r go/pkg/tool/windows_amd64
+  - cd build
+  - 7z a -r go-langserver-windows-amd64.zip go-langserver-windows-amd64 ../go
+
+deploy:
+  release: go-langserver-windows-amd64-draft
+  description: 'Release Draft'
+  provider: Github
+  auth_token:
+    secure: $($env:github_access_token)
+  draft: true
+  artifact: c:\gopath\src\golang.org\x\build\go-langserver-windows-amd64.zip
+  on:
+    branch: master
+


### PR DESCRIPTION
Given that travis ci has poor windows support, use appveyor to test and
deploy the package.