### PR TITLE
[elastic] Use 'DocumentSymbol' for 'documentSymbol' API.

### DIFF
--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -11,7 +11,6 @@ type ElasticServer interface {
 	Server
 	EDefinition(context.Context, *TextDocumentPositionParams) ([]SymbolLocator, error)
 	Full(context.Context, *FullParams) (FullResponse, error)
-	ElasticDocumentSymbol(context.Context, *DocumentSymbolParams, bool, *PackageLocator) ([]SymbolInformation, []DetailSymbolInformation, error)
 	ManageDeps(folders *[]WorkspaceFolder) error
 }
 
@@ -346,7 +345,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 			sendParseError(ctx, r, err)
 			return true
 		}
-		resp, _, err := h.server.ElasticDocumentSymbol(ctx, &params, false, nil)
+		resp, err := h.server.DocumentSymbol(ctx, &params)
 		if err := r.Reply(ctx, resp, err); err != nil {
 			log.Error(ctx, "", err)
 		}


### PR DESCRIPTION
Kibana is trying to use 'DocumentSymbol' to replace 'SymbolInformation'
, so remove the flatten process for 'documentSymbol' API.

It should be noted that 'full' API still use 'SymbolInformation' to
provide the detailed symbol information.

![Use document symbol](https://user-images.githubusercontent.com/5517506/62357083-eec80400-b544-11e9-9d1e-ebea8a22ebd3.jpg)

related issue: https://github.com/elastic/code/issues/1489