### PR TITLE
[elastic] Adjust the build options.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - go test ./internal/lsp
         - mkdir build
         - cd build
-        - go build -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
+        - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
         - curl -o go1.12.7.linux-amd64.tar.gz https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
         - tar xzf go1.12.7.linux-amd64.tar.gz
         - rm -rf ./go/test
@@ -54,31 +54,31 @@ matrix:
           all_branches: true
           tags: true
 
-    - name: Unit Tests & Package | Linux x86
-      os: linux
-      script:
-        - go test ./internal/lsp
-        - mkdir build
-        - cd build
-        - go build -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
-        - curl -o go1.12.7.linux-386.tar.gz https://dl.google.com/go/go1.12.7.linux-386.tar.gz
-        - tar xzf go1.12.7.linux-386.tar.gz
-        - rm -rf ./go/test
-        - tar -zcf go-langserver-linux-386.tar.gz go-langserver go
-
-      deploy:
-        provider: releases
-        skip_cleanup: true
-        api_key: $GITHUB_TOKEN
-        verbose: true
-        file: $GOPATH/src/golang.org/x/tools/build/go-langserver-linux-386.tar.gz
-        name: $TRAVIS_TAG
-        draft: false
-        prerelease: false
-        overwrite: true
-        on:
-          all_branches: true
-          tags: true
+#    - name: Unit Tests & Package | Linux x86
+#      os: linux
+#      script:
+#        - go test ./internal/lsp
+#        - mkdir build
+#        - cd build
+#        - go build -ldflags -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
+#        - curl -o go1.12.7.linux-386.tar.gz https://dl.google.com/go/go1.12.7.linux-386.tar.gz
+#        - tar xzf go1.12.7.linux-386.tar.gz
+#        - rm -rf ./go/test
+#        - tar -zcf go-langserver-linux-386.tar.gz go-langserver go
+#
+#      deploy:
+#        provider: releases
+#        skip_cleanup: true
+#        api_key: $GITHUB_TOKEN
+#        verbose: true
+#        file: $GOPATH/src/golang.org/x/tools/build/go-langserver-linux-386.tar.gz
+#        name: $TRAVIS_TAG
+#        draft: false
+#        prerelease: false
+#        overwrite: true
+#        on:
+#          all_branches: true
+#          tags: true
 
     - name: Unit Tests & Package | OSX
       os: osx
@@ -86,7 +86,7 @@ matrix:
         - go test ./internal/lsp
         - mkdir build
         - cd build
-        - go build -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
+        - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
         - curl -o go1.12.7.darwin-amd64.tar.gz https://dl.google.com/go/go1.12.7.darwin-amd64.tar.gz
         - tar xzf go1.12.7.darwin-amd64.tar.gz
         - rm -rf ./go/test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ image: Visual Studio 2017
 stack: go 1.12.x
 platform:
   - x64
-  - x86
+  #- x86(Appveyor has artifacts packages' size limit, remove the unused x86 artifacts generation)
 
 notifications:
   - provider: GitHubPullRequest
@@ -30,7 +30,7 @@ build_script:
   # - go test ./internal/lsp -v
   - mkdir go-langserver-windows
   - cd go-langserver-windows
-  - go build -o go-langserver.exe c:\gopath\src\golang.org\x\tools\cmd\gopls
+  - go build -ldflags "-s -w" -o go-langserver.exe c:\gopath\src\golang.org\x\tools\cmd\gopls
   - if %platform%==x64 curl -o go1.12.7.windows-%platform%.zip https://dl.google.com/go/go1.12.7.windows-amd64.zip
   - if %platform%==x86 curl -o go1.12.7.windows-%platform%.zip https://dl.google.com/go/go1.12.7.windows-386.zip
   - 7z x go1.12.7.windows-%platform%.zip -o.


### PR DESCRIPTION
Add the option '-ldflags' to strip off the debug info, this option will
reduce the binary size at some extent.

Appveyor will hold the artifacts for 6 month and has the corresponding
size limit, removing the x86 builds will reduce the the artifact size.