### PR TITLE
[elastic] Cache the results of 'invokeGo()' call

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -7,7 +7,8 @@ ENV GO111MODULE=off
 RUN apk add --no-cache --quiet make curl git jq unzip tree && \
      apk add bash && \
      go get golang.org/x/sync/errgroup && \
-     go get golang.org/x/xerrors
+     go get golang.org/x/xerrors && \
+     go get github.com/hashicorp/golang-lru
 
 VOLUME /go/src/golang.org/x/tools
 WORKDIR /go/src/golang.org/x/tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
 before_install:
   - go get golang.org/x/sync/errgroup
   - go get golang.org/x/xerrors
+  - go get github.com/hashicorp/golang-lru
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ environment:
 build_script:
   - go get golang.org/x/sync/errgroup
   - go get golang.org/x/xerrors
+  - go get github.com/hashicorp/golang-lru
   # TODO(henrywong) For now, there are problems about the windows test.
   # - go test ./internal/lsp -v
   - mkdir go-langserver-windows

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module golang.org/x/tools
 go 1.11
 
 require (
+	github.com/hashicorp/golang-lru v0.5.3
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
+github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
'invokeGo' is used to get the import outline of the specified folder(package),
so there are duplications that will slow down the go langserver.

Since go langserver serves several repos at the same time, use LRU cache
in case of blow up the memory. 'determineRootDirsCached' serves single view,
i.e. single workspace folder, 'golistDriverLRUCached' serves single
subfolder, i.e. package. Given that we will skip 'vendor' folder, for now,
the number of the repos are simultaneously indexing is very low, that's
why set the 'determineRootDirsCached' entry number to 16.

Future plan:
1. skip the 'vendor' file
2. download the deps during the initialize request
3. eliminate the 'invokeGo' call
4. find a better approach to handle the 'vendor' folder