### PR TITLE
[elastic] Fix the compile errors after sync to the upstream.

### DIFF
--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -644,7 +644,7 @@ var (
 	goListLRUEntries     = 16 * 32
 )
 
-func golistDriverLRUCached(cfg *Config, rootsDirs func() map[string]string, words ...string) (*driverResponse, error) {
+func golistDriverLRUCached(cfg *Config, rootsDirs func() *goInfo, words ...string) (*driverResponse, error) {
 	createGoListLRUCache.Do(func() {
 		goListLRUCache, _ = lru.New(goListLRUEntries)
 	})

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"golang.org/x/tools/internal/jsonrpc2"
-	"golang.org/x/tools/internal/lsp/telemetry/log"
+	"golang.org/x/tools/internal/telemetry/log"
 )
 
 type ElasticServer interface {

--- a/internal/lsp/workspace.go
+++ b/internal/lsp/workspace.go
@@ -8,8 +8,8 @@ import (
 	"context"
 
 	"golang.org/x/tools/internal/lsp/protocol"
-	"golang.org/x/tools/internal/lsp/telemetry/log"
 	"golang.org/x/tools/internal/span"
+	"golang.org/x/tools/internal/telemetry/log"
 	errors "golang.org/x/xerrors"
 	"os/exec"
 )


### PR DESCRIPTION
Note: The index time increase almost 15% than
https://github.com/elastic/go-langserver/pull/79