### PR TITLE
[elastic] Adjust the ci command to build go-langserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
         - go test ./internal/lsp
         - mkdir build
         - cd build
-        - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
+        - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/gopls
         - curl -o go1.12.7.linux-amd64.tar.gz https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz
         - tar xzf go1.12.7.linux-amd64.tar.gz
         - rm -rf ./go/test
@@ -61,7 +61,7 @@ matrix:
 #        - go test ./internal/lsp
 #        - mkdir build
 #        - cd build
-#        - go build -ldflags -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
+#        - go build -ldflags -o go-langserver $GOPATH/src/golang.org/x/tools/gopls
 #        - curl -o go1.12.7.linux-386.tar.gz https://dl.google.com/go/go1.12.7.linux-386.tar.gz
 #        - tar xzf go1.12.7.linux-386.tar.gz
 #        - rm -rf ./go/test
@@ -87,7 +87,7 @@ matrix:
         - go test ./internal/lsp
         - mkdir build
         - cd build
-        - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/cmd/gopls
+        - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/gopls
         - curl -o go1.12.7.darwin-amd64.tar.gz https://dl.google.com/go/go1.12.7.darwin-amd64.tar.gz
         - tar xzf go1.12.7.darwin-amd64.tar.gz
         - rm -rf ./go/test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
   # - go test ./internal/lsp -v
   - mkdir go-langserver-windows
   - cd go-langserver-windows
-  - go build -ldflags "-s -w" -o go-langserver.exe c:\gopath\src\golang.org\x\tools\cmd\gopls
+  - go build -ldflags "-s -w" -o go-langserver.exe c:\gopath\src\golang.org\x\tools\gopls
   - if %platform%==x64 curl -o go1.12.7.windows-%platform%.zip https://dl.google.com/go/go1.12.7.windows-amd64.zip
   - if %platform%==x86 curl -o go1.12.7.windows-%platform%.zip https://dl.google.com/go/go1.12.7.windows-386.zip
   - 7z x go1.12.7.windows-%platform%.zip -o.


### PR DESCRIPTION
Upstream has moved gopls out of `tools/cmd/gopls` to `tools/gopls`,
change the build command to adapt to this change. No functional changes.