### PR TITLE
[elastic] Try invoke 'go list ...' again if we get nothing from…

### DIFF
--- a/go/packages/golist.go
+++ b/go/packages/golist.go
@@ -653,6 +653,11 @@ func golistDriverLRUCached(cfg *Config, rootsDirs func() *goInfo, words ...strin
 	h.Write([]byte(cfg.Dir))
 	h.Write([]byte(words[len(words)-1]))
 	hashKey := h.Sum32()
+	// If this is a temporary `go list ...` invoke, i.e. without deps information query. Don't entangle it with the go
+	// list cache.
+	if cfg.Mode&(NeedImports|NeedTypes|NeedSyntax|NeedTypesInfo) == 0 {
+		return golistDriver(cfg, rootsDirs, words...)
+	}
 	if val, ok := goListLRUCache.Get(hashKey); ok {
 		res := val.(goListResult)
 		return res.response, res.err


### PR DESCRIPTION
… the previous 'go list ...' invoke

The original 'go list ...' invoke has strict limitations about the load
mode, once 'go list ...' failed, we will get nothing about the packages.

For this case, try to invoke 'go list ...' with weaker limitations, like
without any dependency related information query. Although the 
information we get is limited to the current file, it is better than
nothing.