### PR TITLE
[elastic] Add CGO_ENABLED=0 when we build the go lsp.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ install:
 git:
   depth: 1
 
-env:
-  - GO111MODULE=off GOPROXY=https://proxy.golang.org
-
 before_install:
   - go get golang.org/x/sync/errgroup
   - go get golang.org/x/xerrors
@@ -31,6 +28,11 @@ matrix:
   include:
     - name: Unit Tests & Package | Linux x64
       os: linux
+      env:
+        - GO111MODULE=off
+        - GOPROXY=https://proxy.golang.org
+        - CGO_ENABLED=0
+        - ARCH=x86_64
       script:
         - go test ./internal/lsp
         - mkdir build
@@ -83,6 +85,11 @@ matrix:
 
     - name: Unit Tests & Package | OSX
       os: osx
+      env:
+        - GO111MODULE=off
+        - GOPROXY=https://proxy.golang.org
+        - CGO_ENABLED=0
+        - ARCH=x86_64
       script:
         - go test ./internal/lsp
         - mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
   GOPATH: c:\gopath
   GO111MODULE: off
   GOPROXY: "https://proxy.golang.org"
+  CGO_ENABLED: 0
   github_access_token:
     secure: h4ICNdm1D4g1klCMU6lQ7t92lwIrzo2HHzqc9MJpZdibgfNNFNGwywHWyBa0KPpL
   github_email:


### PR DESCRIPTION
'CGO_ENABLED=0' will enable a full statically linked binary to get rid
of the libc dependency. This option will make the go lsp more portable.