### PR TITLE
[elastic] The changes after sync to the upstream

### DIFF
--- a/internal/lsp/cache/session.go
+++ b/internal/lsp/cache/session.go
@@ -105,8 +105,8 @@ func (s *session) NewView(ctx context.Context, name string, folder span.URI, opt
 	}
 	if enableVendor, ok := ctx.Value("ENABLEVENDOR").(bool); ok && enableVendor {
 		// Set 'GOPROXY=off' to disable the network access
-		v.env = append(v.env, "GOPROXY=off")
-		v.env = append(v.env, "ENABLEVENDOR=on")
+		v.options.Env = append(v.options.Env, "GOPROXY=off")
+		v.options.Env = append(v.options.Env, "ENABLEVENDOR=on")
 	}
 	// Preemptively build the builtin package,
 	// so we immediately add builtin.go to the list of ignored files.

--- a/internal/lsp/cmd/serve.go
+++ b/internal/lsp/cmd/serve.go
@@ -82,7 +82,7 @@ func (s *Serve) Run(ctx context.Context, args ...string) error {
 	}
 
 	// For debugging purposes only.
-	run := func(ctx context.Context, srv *lsp.Server) {
+	run := func(ctx context.Context, srv *lsp.ElasticServer) {
 		go srv.Run(ctx)
 	}
 	if s.Address != "" {

--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -9,7 +9,7 @@ import (
 
 type ElasticServer interface {
 	Server
-	EDefinition(context.Context, *TextDocumentPositionParams) ([]SymbolLocator, error)
+	EDefinition(context.Context, *DefinitionParams) ([]SymbolLocator, error)
 	Full(context.Context, *FullParams) (FullResponse, error)
 	ManageDeps(context.Context, *[]WorkspaceFolder) error
 }
@@ -168,7 +168,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/implementation": // req
-		var params TextDocumentPositionParams
+		var params ImplementationParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -179,7 +179,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/typeDefinition": // req
-		var params TextDocumentPositionParams
+		var params TypeDefinitionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -223,7 +223,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/declaration": // req
-		var params TextDocumentPositionParams
+		var params DeclarationParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -234,7 +234,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "initialize": // req
-		var params InitializeParams
+		var params ParamInitia
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -290,7 +290,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/hover": // req
-		var params TextDocumentPositionParams
+		var params HoverParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -301,7 +301,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/signatureHelp": // req
-		var params TextDocumentPositionParams
+		var params SignatureHelpParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -312,7 +312,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/definition": // req
-		var params TextDocumentPositionParams
+		var params DefinitionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -323,7 +323,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/edefinition":
-		var params TextDocumentPositionParams
+		var params DefinitionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -345,7 +345,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/documentHighlight": // req
-		var params TextDocumentPositionParams
+		var params DocumentHighlightParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true
@@ -467,7 +467,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 		}
 		return true
 	case "textDocument/prepareRename": // req
-		var params TextDocumentPositionParams
+		var params PrepareRenameParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			sendParseError(ctx, r, err)
 			return true

--- a/internal/lsp/source/elastic_util.go
+++ b/internal/lsp/source/elastic_util.go
@@ -1,0 +1,9 @@
+package source
+
+import (
+	"go/types"
+)
+
+func (ident IdentifierInfo) GetDeclObject() types.Object {
+	return ident.Declaration.obj
+}

--- a/internal/lsp/source/options.go
+++ b/internal/lsp/source/options.go
@@ -55,6 +55,8 @@ type Options struct {
 	PreferredContentFormat        protocol.MarkupKind
 	LineFoldingOnly               bool
 
+	InstallGoDependency bool
+
 	SupportedCodeActions map[FileKind]map[protocol.CodeActionKind]bool
 
 	// TODO: Remove the option once we are certain there are no issues here.
@@ -236,6 +238,8 @@ func (o *Options) set(name string, value interface{}) OptionResult {
 	case "wantUnimportedCompletions":
 		result.State = OptionDeprecated
 		result.Replacement = "completeUnimported"
+	case "installGoDependency":
+		result.setBool(&o.InstallGoDependency)
 
 	default:
 		result.State = OptionUnexpected

--- a/internal/lsp/workspace.go
+++ b/internal/lsp/workspace.go
@@ -34,7 +34,8 @@ func (s *Server) changeFolders(ctx context.Context, event protocol.WorkspaceFold
 }
 
 func (s *Server) addView(ctx context.Context, name string, uri span.URI) error {
-	if s.installGoDependency {
+	options := s.session.Options()
+	if options.InstallGoDependency {
 		cmd := exec.Command("go", "mod", "download")
 		cmd.Dir = uri.Filename()
 		if err := cmd.Run(); err != nil {
@@ -44,7 +45,6 @@ func (s *Server) addView(ctx context.Context, name string, uri span.URI) error {
 		// If we disable the go dependency download, trying to find the deps from the vendor folder.
 		ctx = context.WithValue(ctx, "ENABLEVENDOR", true)
 	}
-	view := s.session.NewView(ctx, name, uri)
 	s.stateMu.Lock()
 	state := s.state
 	s.stateMu.Unlock()
@@ -52,7 +52,6 @@ func (s *Server) addView(ctx context.Context, name string, uri span.URI) error {
 		return errors.Errorf("addView called before server initialized")
 	}
 
-	options := s.session.Options()
 	s.fetchConfig(ctx, name, uri, &options)
 	s.session.NewView(ctx, name, uri, options)
 	return nil


### PR DESCRIPTION
The changes contain three parts:

 - The initialize options
 - Since 'IentifierInfo' changes the decl obj into private field, add
 the helper function instead of constructing the decl object by ourselves.
 - Location Mapper