### PR TITLE
[elastic] Only use qname to enable the cross repo jump.

### DIFF
--- a/.ci/script/docker/run_test.sh
+++ b/.ci/script/docker/run_test.sh
@@ -8,5 +8,5 @@ docker run  \
        --rm \
        -v $PWD:/go/src/golang.org/x/tools code-go-langserver-ci \
        /bin/bash -c "set -ex
-            go test ./internal/lsp
+            go test ./internal/lsp -v
        "

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - CGO_ENABLED=0
         - ARCH=x86_64
       script:
-        - go test ./internal/lsp
+        - go test ./internal/lsp -v
         - mkdir build
         - cd build
         - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/gopls
@@ -94,7 +94,7 @@ matrix:
         - CGO_ENABLED=0
         - ARCH=x86_64
       script:
-        - go test ./internal/lsp
+        - go test ./internal/lsp -v
         - mkdir build
         - cd build
         - go build -ldflags "-s -w" -o go-langserver $GOPATH/src/golang.org/x/tools/gopls

--- a/internal/lsp/elasticext_test.go
+++ b/internal/lsp/elasticext_test.go
@@ -30,7 +30,7 @@ func testLSPExt(t *testing.T, exporter packagestest.Exporter) {
 	// We hardcode the expected number of test cases to ensure that all tests
 	// are being executed. If a test is added, this number must be changed.
 	const expectedQNameKindCount = 7
-	const expectedPkgLocatorCount = 6
+	const expectedPkgLocatorCount = 0
 	const expectedFullSymbolCount = 14
 
 	files := packagestest.MustCopyFileTree(dir)

--- a/internal/lsp/elasticserver.go
+++ b/internal/lsp/elasticserver.go
@@ -88,21 +88,32 @@ func (s *ElasticServer) EDefinition(ctx context.Context, params *protocol.Defini
 	if err != nil {
 		return nil, err
 	}
+	// Check whether the definition is in the current view, i.e. workspace folders. One repo may has several workspace folders.
+	if strings.HasPrefix(ident.Declaration.URI().Filename(), view.Folder().Filename()) {
+		// If it is the same-workspace folder jump, return early.
+		return []protocol.SymbolLocator{{
+			Loc: &protocol.Location{
+				URI:   protocol.NewURI(ident.Declaration.URI()),
+				Range: declRange,
+			},
+			Package: protocol.PackageLocator{},
+		}}, nil
+	}
+	// If it is the cross-view jump, only return the qname, symbol kind and package locator.
 	declObj := ident.GetDeclObject()
+	declURI := ident.Declaration.URI()
+	declFile, err := view.GetFile(ctx, declURI)
+	if err != nil {
+		return nil, err
+	}
 	kind := getSymbolKind(declObj)
 	if kind == 0 {
 		return nil, fmt.Errorf("no corresponding symbol kind for '" + ident.Name + "'")
 	}
-	qname := getQName(ctx, view, f, declObj, kind)
-	declURI := ident.Declaration.URI()
+	qname := getQName(ctx, view, declFile, declObj, kind)
 	declPath := declURI.Filename()
-	pkgLocator, scheme := collectPkgMetadata(declObj.Pkg(), view.Folder().Filename(), declPath)
-	declPath = normalizePath(declPath, view.Folder().Filename(), strings.TrimPrefix(pkgLocator.RepoURI, scheme), pkgMod)
-	loc := protocol.Location{
-		URI:   normalizeLoc(declURI.Filename(), pkgMod, &pkgLocator, declPath),
-		Range: declRange,
-	}
-	return []protocol.SymbolLocator{{Qname: qname, Kind: kind, Path: declPath, Loc: loc, Package: pkgLocator}}, nil
+	pkgLocator := collectPkgMetadata(declObj.Pkg(), view.Folder().Filename(), declPath)
+	return []protocol.SymbolLocator{{Qname: qname, Kind: kind, Package: pkgLocator}}, nil
 }
 
 const (
@@ -137,7 +148,7 @@ func (s *ElasticServer) Full(ctx context.Context, fullParams *protocol.FullParam
 	if err != nil {
 		return fullResponse, err
 	}
-	pkgLocator, _ := collectPkgMetadata(pkg.GetTypes(), view.Folder().Filename(), path)
+	pkgLocator := collectPkgMetadata(pkg.GetTypes(), view.Folder().Filename(), path)
 
 	detailSyms, err := constructDetailSymbol(s, ctx, &params, &pkgLocator)
 	if err != nil {
@@ -264,7 +275,7 @@ func getQName(ctx context.Context, view source.View, f source.File, declObj type
 	}
 	s := view.Snapshot()
 	fh := s.Handle(ctx, f)
-	fAST, _, _, err := view.Session().Cache().ParseGoHandle(fh, source.ParseFull).Parse(ctx)
+	fAST, _, _, err := view.Session().Cache().ParseGoHandle(fh, source.ParseExported).Parse(ctx)
 	if err != nil {
 		return ""
 	}
@@ -310,20 +321,6 @@ func getQName(ctx context.Context, view source.View, f source.File, declObj type
 
 		case *ast.FuncDecl:
 			f, _ := n.(*ast.FuncDecl)
-			if f.Name != nil && f.Name.Name != qname && (kind == protocol.Method || kind == protocol.Function) {
-				qname = f.Name.Name + "." + qname
-			}
-
-			if f.Name != nil {
-				if kind == protocol.Method || kind == protocol.Function {
-					if f.Name.Name != qname {
-						qname = f.Name.Name + "." + qname
-					}
-				} else {
-					qname = f.Name.Name + "." + qname
-				}
-			}
-
 			// If n is method, add the struct name as a prefix.
 			if f.Recv != nil {
 				var typeName string
@@ -335,20 +332,6 @@ func getQName(ctx context.Context, view source.View, f source.File, declObj type
 				}
 				qname = typeName + "." + qname
 			}
-		case *ast.FuncLit:
-			// Considering the function literal is for making the local variable declared in it more unique, the
-			// handling is a little tricky. If the function literal is assigned to a named entity, like variable, it is
-			// better consider the variable name into the qualified name.
-
-			// Check its ancestors to decide where it is located in, like a assignment, variable declaration, or a
-			// return statement.
-			switch astPath[id+2].(type) {
-			case *ast.AssignStmt:
-				as, _ := astPath[id+2].(*ast.AssignStmt)
-				if i, ok := as.Lhs[0].(*ast.Ident); ok {
-					qname = i.Name + "." + qname
-				}
-			}
 		}
 	}
 	if declObj.Pkg() == nil {
@@ -359,26 +342,25 @@ func getQName(ctx context.Context, view source.View, f source.File, declObj type
 
 // collectPackageMetadata collects metadata for the packages where the specified symbols located and the scheme, i.e.
 // URL prefix, of the repository which the packages belong to.
-func collectPkgMetadata(pkg *types.Package, dir string, loc string) (protocol.PackageLocator, string) {
+func collectPkgMetadata(pkg *types.Package, dir string, loc string) protocol.PackageLocator {
 	if pkg == nil {
-		return protocol.PackageLocator{}, ""
+		return protocol.PackageLocator{}
 	}
 	pkgLocator := protocol.PackageLocator{
 		Name:    pkg.Name(),
 		RepoURI: pkg.Path(),
 	}
-	// If the location is inside the current project or the location from standard library, there is no need to resolve
-	// the revision.
+	// If the package is located in the standard library, there is no need to resolve the revision.
 	if strings.HasPrefix(loc, dir) || strings.HasPrefix(loc, goRoot) {
-		return pkgLocator, ""
+		return pkgLocator
 	}
 	getPkgVersion(dir, &pkgLocator, loc)
 	repoRoot, err := vcs.RepoRootForImportPath(pkg.Path(), false)
 	if err == nil {
 		pkgLocator.RepoURI = repoRoot.Repo
-		return pkgLocator, strings.TrimSuffix(repoRoot.Repo, repoRoot.Root)
+		return pkgLocator
 	}
-	return pkgLocator, ""
+	return pkgLocator
 }
 
 // getPkgVersion collects the version information for a specified package, the version information will be one of the
@@ -426,34 +408,6 @@ func getPkgVersionFast(loc string) string {
 		return ""
 	}
 	return validVersion[0]
-}
-
-// normalizeLoc concatenates repository URL, package version and file path to get a complete location URL for the
-// location located in the dependencies.
-func normalizeLoc(loc string, depsPath string, pkgLocator *protocol.PackageLocator, path string) string {
-	loc = strings.TrimPrefix(loc, "file://")
-	if strings.HasPrefix(loc, depsPath) {
-		strs := []string{"blob", pkgLocator.Version, path}
-		return pkgLocator.RepoURI + string(filepath.Separator) + filepath.Join(strs...)
-	}
-	return "file://" + loc
-}
-
-// normalizePath trims the workspace folder prefix to get the file path in project. Remove the revision embedded in the
-// path if it exists.
-func normalizePath(path, dir, repoURI, depsPath string) string {
-	if strings.HasPrefix(path, dir) {
-		path = strings.TrimPrefix(path, dir)
-	} else {
-		path = strings.TrimPrefix(path, filepath.Join(depsPath, repoURI))
-		rev := getPkgVersionFast(path)
-		if rev != "" {
-			strs := strings.Split(path, rev)
-			i := strings.LastIndex(strs[0], "@")
-			path = filepath.Join(path[:i], strs[1])
-		}
-	}
-	return strings.TrimPrefix(path, string(filepath.Separator))
 }
 
 var (

--- a/internal/lsp/protocol/elasticext.go
+++ b/internal/lsp/protocol/elasticext.go
@@ -9,15 +9,17 @@ type PackageLocator struct {
 // SymbolLocator is the response type for the `textDocument/edefinition` extension.
 type SymbolLocator struct {
 	// The fully qualified name of the symbol.
-	Qname string `json:"qname"`
+	Qname string `json:"qname,omitempty"`
 
 	Kind SymbolKind `json:"kind,omitempty"`
 
 	// The file path relative to the repo root URI of the specified symbol.
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// A concrete location at which the definition is located.
-	Loc Location `json:"location,omitempty"`
+	// TODO(henrywong) 'encoding/json' doesn't support the zero values of structs with omitempty for now, see
+	//  https://github.com/golang/go/issues/11939. That's why we use pointer here.
+	Loc *Location `json:"location,omitempty"`
 
 	Package PackageLocator `json:"package,omitempty"`
 }

--- a/internal/lsp/testdata/lspext/edefinition/packagelocator.go
+++ b/internal/lsp/testdata/lspext/edefinition/packagelocator.go
@@ -1,24 +1,28 @@
-package edefinition //Test fail here, edefinition("def", "edefinition", 4)
+package edefinition
 
 import (
-	jsoniter "github.com/json-iterator/go"
 	"golang.org/x/tools/internal/lsp/foo"
 	"golang.org/x/tools/internal/lsp/godef/a"
 	"golang.org/x/tools/internal/lsp/godef/b"
 	"golang.org/x/tools/internal/lsp/types"
 )
 
+// NOTE: EDefinition will give different result for the repository URI, will give the import path without the network
+// access. And give actual repository URI with the network enabled.
+
+// Disable the test temporarily until we find the consistent solution.
+
 func packageLocator() {
-	b.Bar() //@packagelocator("B", "b", "https://go.googlesource.com/tools")
+	b.Bar() //packagelocator("B", "b", "https://go.googlesource.com/tools")
 
-	s := b.S1{} //@packagelocator("S", "b", "https://go.googlesource.com/tools")
+	s := b.S1{} //packagelocator("S", "b", "https://go.googlesource.com/tools")
 
-	str := a.A //@packagelocator("A", "a", "https://go.googlesource.com/tools")
+	str := a.A //packagelocator("A", "a", "https://go.googlesource.com/tools")
 
-	var i foo.IntFoo //@packagelocator("I", "foo", "https://go.googlesource.com/tools")
+	var i foo.IntFoo //packagelocator("I", "foo", "https://go.googlesource.com/tools")
 
-	var bob types.Bob //@packagelocator("B", "types", "https://go.googlesource.com/tools")
+	var bob types.Bob //packagelocator("B", "types", "https://go.googlesource.com/tools")
 
 	var x types.X
-	x.Bobby() //@packagelocator("B", "types", "https://go.googlesource.com/tools")
+	x.Bobby() //packagelocator("B", "types", "https://go.googlesource.com/tools")
 }

--- a/internal/lsp/testdata/lspext/edefinition/packagelocator.go
+++ b/internal/lsp/testdata/lspext/edefinition/packagelocator.go
@@ -1,12 +1,24 @@
-package edefinition
+package edefinition //Test fail here, edefinition("def", "edefinition", 4)
 
 import (
-	"fmt"
+	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/tools/internal/lsp/foo"
+	"golang.org/x/tools/internal/lsp/godef/a"
+	"golang.org/x/tools/internal/lsp/godef/b"
+	"golang.org/x/tools/internal/lsp/types"
 )
 
-// There is a bug in this test framework that it can't get the identifier from the imports nonofficial package in the
-// test process. Like can get the identifier 'Println' from "fmt", but can't get the identifier 'Direction' from 'jsonrpc2'.
-func pkgloc() { //@packagelocator("loc", "edefinition", "golang.org/x/tools/internal/lsp/lspext/edefinition")
-	// var d jsonrpc2.Direction
-	fmt.Println(0) //@packagelocator("rintln", "fmt", "fmt")
+func packageLocator() {
+	b.Bar() //@packagelocator("B", "b", "https://go.googlesource.com/tools")
+
+	s := b.S1{} //@packagelocator("S", "b", "https://go.googlesource.com/tools")
+
+	str := a.A //@packagelocator("A", "a", "https://go.googlesource.com/tools")
+
+	var i foo.IntFoo //@packagelocator("I", "foo", "https://go.googlesource.com/tools")
+
+	var bob types.Bob //@packagelocator("B", "types", "https://go.googlesource.com/tools")
+
+	var x types.X
+	x.Bobby() //@packagelocator("B", "types", "https://go.googlesource.com/tools")
 }

--- a/internal/lsp/testdata/lspext/edefinition/qnamekind.go
+++ b/internal/lsp/testdata/lspext/edefinition/qnamekind.go
@@ -2,6 +2,10 @@ package edefinition //Test fail here, edefinition("def", "edefinition", 4)
 
 import (
 	"fmt"
+	"golang.org/x/tools/internal/lsp/foo"
+	"golang.org/x/tools/internal/lsp/godef/a"
+	"golang.org/x/tools/internal/lsp/godef/b"
+	"golang.org/x/tools/internal/lsp/types"
 )
 
 // FileSymbol          SymbolKind = 1
@@ -31,195 +35,26 @@ import (
 // OperatorSymbol      SymbolKind = 25
 // TypeParameterSymbol SymbolKind = 26
 
-// Note: '@qnamekind("first", "second", number)', means check the location where the first element located, the second
-// element represents the qualified name, the third element represents the symbol kind.
+func qnameKind() {
+	// FunctionSymbol
+	b.Bar() //@qnamekind("B", "b.Bar", 12)
 
-// Test struct declaration and the field declarations.
-type Circle struct { //@qnamekind("cle", "edefinition.Circle", 23)
-	r    float64  //@qnamekind("r", "edefinition.Circle.r", 8)
-	Node struct { //@qnamekind("e", "edefinition.Circle.Node", 8)
-		x int //@qnamekind("x", "edefinition.Circle.Node.x", 8)
-		y int
-	}
+	// StructSymbol
+	s := b.S1{} //@qnamekind("S", "b.S1", 23)
+
+	// FieldSymbol
+	fmt.Println(s.F1) //@qnamekind("F1", "b.S1.F1", 8)
+
+	// StringSymbol
+	str := a.A //@qnamekind("A", "a.A", 15)
+
+	// NumberSymbol
+	var i foo.IntFoo //@qnamekind("I", "foo.IntFoo", 16)
+
+	// InterfaceSymbol
+	var bob types.Bob //@qnamekind("B", "types.Bob", 11)
+
+	var x types.X
+	// MethodSymbol
+	x.Bobby() //@qnamekind("B", "types.X.Bobby", 6)
 }
-
-// Test function declaration and variables.
-func func1() int { //@qnamekind("c1", "edefinition.func1", 12)
-	lhs := 10          //@qnamekind("lhs", "edefinition.func1.lhs", 13)
-	const rhs int = 20 //@qnamekind("rhs", "edefinition.func1.rhs", 14)
-	return lhs + rhs   //@qnamekind("rhs", "edefinition.func1.rhs", 14)
-}
-
-// Test method declaration and field access.
-func (c *Circle) method1() { //@qnamekind("method1", "edefinition.Circle.method1", 6)
-	fmt.Print(c.r) //@qnamekind("fmt", "fmt", 4),qnamekind("Pri", "fmt.Print", 12)
-
-	fmt.Print(c.Node.x) //@qnamekind("No", "edefinition.Circle.Node", 8)
-}
-
-// Test the interface declaration and method declaration.
-type Shape interface { //@qnamekind("ha", "edefinition.Shape", 11)
-	Area() int //@qnamekind("Are", "edefinition.Shape.Area", 6)
-}
-
-// Test method call and the variabel declaration in a nested scope.
-func func2() {
-	var c Circle //@qnamekind("c", "edefinition.func2.c", 13)
-	c.method1()  //@qnamekind("meth", "edefinition.Circle.method1", 6),qnamekind("c", "edefinition.func2.c", 13)
-
-	{
-		num := 20 //@qnamekind("num", "edefinition.func2.num", 13)
-		fmt.Println(num)
-	}
-}
-
-// Test the struct declared in a function.
-func structInFunc() {
-	type A struct { //@qnamekind("A", "edefinition.structInFunc.A", 23)
-		x int //@qnamekind("x", "edefinition.structInFunc.A.x", 8)
-		y int
-	}
-
-	a := &A{x: 10, y: 20} //@qnamekind("x", "edefinition.structInFunc.A.x", 8)
-	fmt.Println(a.x, a.y)
-}
-
-// Test the named structs which have the same name and declared in different scopes.
-func structInAnonyScopes() {
-	{
-		type A struct { //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
-			x int //@qnamekind("x", "edefinition.structInAnonyScopes.A.x", 8)
-		}
-
-		a := &A{x: 10} //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
-		fmt.Println(a)
-	}
-
-	{
-		type A struct { //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
-			x int
-		}
-
-		a := &A{x: 10} //@qnamekind("A", "edefinition.structInAnonyScopes.A", 23)
-		fmt.Println(a)
-	}
-}
-
-// Test the local variable declared in the method declaration.
-func (c *Circle) method2() {
-	num := 10        //@qnamekind("nu", "edefinition.Circle.method2.num", 13)
-	fmt.Println(num) //@qnamekind("Pri", "fmt.Println", 12)
-}
-
-// Test the field located in a struct which declared in a method declaration.
-func (c *Circle) method3() {
-	type Rectangle struct {
-		x int
-		y int //@qnamekind("y", "edefinition.Circle.method3.Rectangle.y", 8)
-	}
-}
-
-// Test the method whose receiver has a value type.
-func (c Circle) method4() float64 { //@qnamekind("tho", "edefinition.Circle.method4", 6)
-	return c.r
-}
-
-// Test the variable declared in an anonymous functions case#1.
-func func4() {
-	f := func(x int) int {
-		num := 10 //@qnamekind("num", "edefinition.func4.f.num", 13)
-		return x + num
-	}
-	fmt.Println(f(1))
-}
-
-// Test the variable declared in an anonymous functions case#2.
-func func5() func(int) int {
-	return func(x int) int {
-		num := 10 //@qnamekind("nu", "edefinition.func5.num", 13)
-		return x + num
-	}
-}
-
-// Test the variable declared in an anonymous functions case#3.
-func func6() (f func(int) int) {
-	f = func(x int) int {
-		num := 10 //@qnamekind("n", "edefinition.func6.f.num", 13)
-		return x + num
-	}
-	return
-}
-
-// Test the field symbol in an anonymous type case#1.
-func func7() {
-	var node struct {
-		x int //@qnamekind("x", "edefinition.func7.node.x", 8)
-		y int
-	}
-	fmt.Println(node)
-}
-
-// Test the field symbol in an anonymous type case#2.
-func func8(pair struct {
-	x int //@qnamekind("x", "edefinition.func8.pair.x", 8)
-	y int
-}) int {
-	return pair.x + pair.y
-}
-
-// Test the field symbol in an anonymous type case#3
-func func9(x int, y int) (pair struct { //@qnamekind("x", "edefinition.func9.x", 13)
-	x int //@qnamekind("x", "edefinition.func9.pair.x", 8)
-	y int
-}) {
-	pair.x = x
-	pair.y = y
-	return
-}
-
-// Test the field symbol in a anonymous type case#4
-func func10() {
-	// In this case just consider the first variable's name.
-	var node1, node2 struct {
-		x int //@qnamekind("x", "edefinition.func10.node1.x", 8)
-		y int
-	}
-	fmt.Println(node1)
-	fmt.Println(node2)
-}
-
-// Test the named return parameters.
-func func11(lhs int, rhs int) (sum int) { //@qnamekind("su", "edefinition.func11.sum", 13)
-	sum = lhs + rhs
-	return
-}
-
-type struct_alias = Circle //@qnamekind("str", "edefinition.struct_alias", 23)
-type struct_tydef Circle   //@qnamekind("tydef", "edefinition.struct_tydef", 23)
-
-type interface_alias = Shape //@qnamekind("interface_alias", "edefinition.interface_alias", 11)
-type interface_tydef Shape   //@qnamekind("interface_tydef", "edefinition.interface_tydef", 11)
-
-type int_basic_alias = int //@qnamekind("int_basic_alias", "edefinition.int_basic_alias", 16)
-type int_tydef int         //@qnamekind("int_tydef", "edefinition.int_tydef", 16)
-
-type float_basic_alias = float64 //@qnamekind("float_basic_alias", "edefinition.float_basic_alias", 16)
-type float_basic_tydef float64   //@qnamekind("float_basic_tydef", "edefinition.float_basic_tydef", 16)
-
-type bool_basic_alias = bool //@qnamekind("bool_basic_alias", "edefinition.bool_basic_alias", 17)
-type bool_basic_tydef bool   //@qnamekind("bool_basic_tydef", "edefinition.bool_basic_tydef", 17)
-
-type string_basic_alias = string //@qnamekind("string_basic_alias", "edefinition.string_basic_alias", 15)
-type string_basic_tydef string   //@qnamekind("string_basic_tydef", "edefinition.string_basic_tydef", 15)
-
-type int_slice_alias = []int //@qnamekind("int_slice_alias", "edefinition.int_slice_alias", 18)
-type int_slice_tydef = []int //@qnamekind("int_slice_tydef", "edefinition.int_slice_tydef", 18)
-
-type string_slice_alias = []string //@qnamekind("ing_slice_alias", "edefinition.string_slice_alias", 18)
-type string_slice_tydef = []string //@qnamekind("string_slice_tydef", "edefinition.string_slice_tydef", 18)
-
-type int_array_alias = []int //@qnamekind("int_ar", "edefinition.int_array_alias", 18)
-type int_array_tydef = []int //@qnamekind("t_array_tydef", "edefinition.int_array_tydef", 18)
-
-type string_array_alias = []string //@qnamekind("string_ar", "edefinition.string_array_alias", 18)
-type string_array_tydef = []string //@qnamekind("ray_tydef", "edefinition.string_array_tydef", 18)

--- a/internal/lsp/testdata/lspext/edefinition/qnamekind.go
+++ b/internal/lsp/testdata/lspext/edefinition/qnamekind.go
@@ -46,7 +46,7 @@ func qnameKind() {
 	fmt.Println(s.F1) //@qnamekind("F1", "b.S1.F1", 8)
 
 	// StringSymbol
-	str := a.A //@qnamekind("A", "a.A", 15)
+	var str a.A //@qnamekind("A", "a.A", 15)
 
 	// NumberSymbol
 	var i foo.IntFoo //@qnamekind("I", "foo.IntFoo", 16)


### PR DESCRIPTION
Originally I construct the `location.uri` for the all cases, like
`uri":"https://github.com/Shopify/sarama/blob/v1.23.1/config.go`.
However there is no need to construct this value. Remove it.

This PR has three parts:

 - Remove the code which is used to construct the `location.uri`,
   including `normalizeLoc` and `normalizePath`
 - Adjust the test, qname is only used to enable the cross repo jump.
 - Use `source.ParseExported` instead of `source.ParseFull` to parse the
   dependencies

Note:There is no proper approach to construct the qname of the symbols
of dependencies when we disable the dependencies download.

Fix https://github.com/elastic/code/issues/1653.
And since we only use qname to enable the cross-repo jump, so the issue https://github.com/elastic/go-langserver/pull/92 is invalid.