### PR TITLE
[elastic] Move the dependencies downloading into `ManageDeps`

### DIFF
--- a/internal/lsp/protocol/elasticserver.go
+++ b/internal/lsp/protocol/elasticserver.go
@@ -11,7 +11,7 @@ type ElasticServer interface {
 	Server
 	EDefinition(context.Context, *DefinitionParams) ([]SymbolLocator, error)
 	Full(context.Context, *FullParams) (FullResponse, error)
-	ManageDeps(context.Context, *[]WorkspaceFolder, interface{}) error
+	ManageDeps(context.Context, *[]WorkspaceFolder, interface{})
 	Cleanup()
 }
 
@@ -56,9 +56,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 			sendParseError(ctx, r, err)
 			return true
 		}
-		if err := h.server.ManageDeps(ctx, &params.Event.Added, nil); err != nil {
-			log.Error(ctx, "", err)
-		}
+		h.server.ManageDeps(ctx, &params.Event.Added, nil)
 		if err := h.server.DidChangeWorkspaceFolders(ctx, &params); err != nil {
 			log.Error(ctx, "", err)
 		}
@@ -240,16 +238,7 @@ func (h elasticServerHandler) Deliver(ctx context.Context, r *jsonrpc2.Request, 
 			sendParseError(ctx, r, err)
 			return true
 		}
-		installDeps := false
-		// Peek the 'installGoDependency' option.
-		if opts, ok := params.InitializationOptions.(map[string]interface{}); ok {
-			if opt, ok := opts["installGoDependency"].(bool); ok && opt {
-				installDeps = true
-			}
-		}
-		if err := h.server.ManageDeps(ctx, &params.WorkspaceFolders, installDeps); err != nil {
-			log.Error(ctx, "", err)
-		}
+		h.server.ManageDeps(ctx, &params.WorkspaceFolders, params.InitializationOptions)
 		resp, err := h.server.Initialize(ctx, &params)
 		if err := r.Reply(ctx, resp, err); err != nil {
 			log.Error(ctx, "", err)


### PR DESCRIPTION
As the sub-functionality of dependencies management, it's better to move
dependencies download into `ManageDeps`. Dependencies downloading is
originally bound to `addView()`, but https://go-review.googlesource.com/c/tools/+/194278
put `addView` into `initialized` handler. Refactor dependencies
downloading out into `ManageDeps`, all the dependency related handle will
be done before the initialize handler(and the `didChangeWorkspaceFolder`
handler). And there is no need to put the `addView()` back into `initialize`
handler to complete the dependencies downloading in the `initialize` handler.

This PR:
 - Move dependencies downloading from `addView` to `DepsManager`
 - If the dependencies downloading failed, put the folder under vendor
   mode. Since there is no perfect way to tell `addView` which folder
   should be under vendor mode, use closure to pass that info.
 - Add environment variable `GOPROXY` to speed up the dependencies
   downloading.
 - btw, little code refactor about `DepsManager`, put the deps related
   stuff into `DepsManager`, like the body  of `run()` is extracted from
   original `ManageDeps()`

The context of CL https://go-review.googlesource.com/c/tools/+/194278:
 - The client sends the initial options through the `initialize` handler.
 - Workspace folders may need specified build flags which needs the server
   sends `workspace/configuration` back to the client after the `initialize`
   request completed. `workspace/configuration` was added in LSP 3.6
   several months ago.
 - To fetch build flags, needs to construct the view after the `initialize`
   request completed.

Related Issue:
elastic/code#1661
microsoft/language-server-protocol#567 (comment)