### PR TITLE
[elastic] Fix the travis-ci failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ install:
       git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge;
       git checkout -qf FETCH_HEAD;
     fi
+  - go get -t honnef.co/go/tools/simple
+  - go get -t honnef.co/go/tools/staticcheck
+  - go get -t honnef.co/go/tools/stylecheck
 
 git:
   depth: 1
@@ -22,9 +25,6 @@ before_install:
   - go get -t golang.org/x/sync/errgroup
   - go get -t golang.org/x/xerrors
   - go get -t github.com/hashicorp/golang-lru
-  - go get -t honnef.co/go/tools/simple
-  - go get -t honnef.co/go/tools/staticcheck
-  - go get -t honnef.co/go/tools/stylecheck
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
The `go get -t honnef.co/go/tools/simple` command has contradictions
with the `git clone`, move it after we checkout the specified PR.